### PR TITLE
Iterative/Delta Manifest Format Guard

### DIFF
--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -498,7 +498,7 @@ func CreateManifests(version uint32, minVersion uint32, format uint, statedir st
 	// Create Iterative manifests if there isn't a format bump or minVersion
 	if format == oldFormat && minVersion != version {
 		var iManifests []*Manifest
-		iManifests, err = newMoM.writeIterativeManifests(newManifests, verOutput)
+		iManifests, err = newMoM.writeIterativeManifestsForFormat(newManifests, verOutput)
 		if err != nil {
 			return nil, err
 		}

--- a/swupd/create_manifests_test.go
+++ b/swupd/create_manifests_test.go
@@ -39,11 +39,14 @@ func TestCreateManifestsBasic(t *testing.T) {
 
 	ts.Bundles = []string{"test-bundle"}
 
+	// Iterative manifests are not supported in formats < 26
+	ts.Format = 26
+
 	ts.addFile(10, "test-bundle", "/foo", "content")
 	ts.createManifests(10)
 
 	expSubs := []string{
-		"MANIFEST\t1",
+		"MANIFEST\t26",
 		"version:\t10",
 		"previous:\t0",
 		"filecount:\t2",
@@ -66,7 +69,7 @@ func TestCreateManifestsBasic(t *testing.T) {
 	ts.createManifests(20)
 
 	expSubs = []string{
-		"MANIFEST\t1",
+		"MANIFEST\t26",
 		"version:\t20",
 		"previous:\t10",
 		"filecount:\t2",
@@ -78,7 +81,7 @@ func TestCreateManifestsBasic(t *testing.T) {
 	checkManifestNotContains(t, ts.Dir, "20", "MoM", "20\tManifest.full")
 
 	expSubs = []string{
-		"MANIFEST\t1",
+		"MANIFEST\t26",
 		"version:\t20",
 		"previous:\t10",
 		"filecount:\t1",
@@ -88,7 +91,7 @@ func TestCreateManifestsBasic(t *testing.T) {
 	checkManifestFileCount(ts, "20", "os-core.I.10", 1, 0)
 
 	expSubs = []string{
-		"MANIFEST\t1",
+		"MANIFEST\t26",
 		"version:\t20",
 		"previous:\t10",
 		"filecount:\t1",
@@ -103,6 +106,10 @@ func TestCreateManifestsDeleteNoVerBump(t *testing.T) {
 	ts := newTestSwupd(t, "delete-no-version-bump")
 	defer ts.cleanup()
 	ts.Bundles = []string{"test-bundle1", "test-bundle2"}
+
+	// Iterative manifests are not supported in formats < 26
+	ts.Format = 26
+
 	ts.addFile(10, "test-bundle1", "/foo", "content")
 	ts.addFile(10, "test-bundle2", "/foo", "content")
 	ts.createManifests(10)
@@ -115,7 +122,7 @@ func TestCreateManifestsDeleteNoVerBump(t *testing.T) {
 	fileInManifest(t, ts.parseManifest(20, "full"), 10, "/foo")
 
 	expSubs := []string{
-		"MANIFEST\t1",
+		"MANIFEST\t26",
 		"version:\t20",
 		"previous:\t10",
 		"filecount:\t1",
@@ -165,6 +172,10 @@ func TestCreateManifestGhosted(t *testing.T) {
 	ts := newTestSwupd(t, "ghosted")
 	defer ts.cleanup()
 	ts.Bundles = []string{"test-bundle"}
+
+	// Iterative manifests are not supported in formats < 26
+	ts.Format = 26
+
 	ts.addFile(10, "test-bundle", "/usr/lib/kernel/bar", "bar")
 	ts.createManifests(10)
 
@@ -274,6 +285,10 @@ func TestCreateManifestsMoM(t *testing.T) {
 	ts := newTestSwupd(t, "MoM")
 	defer ts.cleanup()
 	ts.Bundles = []string{"test-bundle1", "test-bundle2", "test-bundle3", "test-bundle4"}
+
+	// Iterative manifests are not supported in formats < 26
+	ts.Format = 26
+
 	ts.createManifests(10)
 
 	// initial update, all manifests should be present at this version
@@ -388,6 +403,10 @@ func TestCreateManifestResurrect(t *testing.T) {
 	ts := newTestSwupd(t, "resurrect-file")
 	defer ts.cleanup()
 	ts.Bundles = []string{"test-bundle"}
+
+	// Iterative manifests are not supported in formats < 26
+	ts.Format = 26
+
 	ts.addFile(10, "test-bundle", "/foo", "foo")
 	ts.addFile(10, "test-bundle", "/foo1", "foo1")
 	ts.createManifests(10)
@@ -396,7 +415,7 @@ func TestCreateManifestResurrect(t *testing.T) {
 	ts.createManifests(20)
 
 	expSubs := []string{
-		"MANIFEST\t1",
+		"MANIFEST\t26",
 		"version:\t20",
 		"previous:\t10",
 		"filecount:\t1",
@@ -409,7 +428,7 @@ func TestCreateManifestResurrect(t *testing.T) {
 	ts.createManifests(30)
 
 	expSubs = []string{
-		"MANIFEST\t1",
+		"MANIFEST\t26",
 		"version:\t30",
 		"previous:\t20",
 		"filecount:\t2",

--- a/swupd/delta_test.go
+++ b/swupd/delta_test.go
@@ -70,6 +70,9 @@ func TestNoDeltasForTypeChangesOrDereferencedSymlinks(t *testing.T) {
 	defer ts.cleanup()
 	ts.Bundles = []string{"os-core"}
 
+	// Delta manifests are not supported in formats < 26
+	ts.Format = 26
+
 	// NOTE: Currently the delta is compared to the real file, but a better
 	// approximation comparison would be with a compressed version of the real file
 	// (fullfile), since the delta itself will already be compressed, so packing won't

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -60,6 +60,15 @@ includes:	{{.Name}}
 `,
 }
 
+// Iterative manifests were introduced in format 26 and will cause issues with older formats
+func (m *Manifest) writeIterativeManifestsForFormat(newManifests []*Manifest, out string) ([]*Manifest, error) {
+	if m.Header.Format <= 25 {
+		return nil, nil
+	}
+
+	return m.writeIterativeManifests(newManifests, out)
+}
+
 // manifestTemplateForFormat returns the *template.Template for creating
 // manifests for the provided format f
 func manifestTemplateForFormat(f uint) (t *template.Template) {

--- a/swupd/format_switch.go
+++ b/swupd/format_switch.go
@@ -15,6 +15,7 @@
 package swupd
 
 import (
+	"archive/tar"
 	"text/template"
 )
 
@@ -58,6 +59,15 @@ includes:	{{.Name}}
 {{.GetFlagString}}	{{.Hash}}	{{.Version}}	{{.Name}}
 {{- end}}
 `,
+}
+
+// Delta manifests were introduced in format 26 and should not be created in older formats
+func writeDeltaManifestForFormat(tw *tar.Writer, outputDir string, dManifest *Manifest, toVersion uint32) error {
+	if dManifest == nil || dManifest.Header.Format <= 25 {
+		return nil
+	}
+
+	return writeDeltaManifest(tw, outputDir, dManifest, toVersion)
 }
 
 // Iterative manifests were introduced in format 26 and will cause issues with older formats

--- a/swupd/format_switch_test.go
+++ b/swupd/format_switch_test.go
@@ -1,21 +1,27 @@
 package swupd
 
 import (
+	"strings"
 	"testing"
 )
 
-// Format 25 should not support minversions or iterative manifests. Support for
-// these features was added in format 26.
+// Format 25 should not support minversions, iterative manifests, or delta manifests.
+// Support for these features was added in format 26.
 func TestManifestFormats25to26(t *testing.T) {
 	ts := newTestSwupd(t, "format25to26")
 	defer ts.cleanup()
 
 	ts.Bundles = []string{"test-bundle"}
 
+	contents := strings.Repeat("large", 1000)
+	if len(contents) < minimumSizeToMakeDeltaInBytes {
+		t.Fatal("test content size is invalid")
+	}
+
 	// format25 MoM should NOT have minversion in header, which is introduced
 	// in format26. (It should also not have it because minversion is set to 0)
 	ts.Format = 25
-	ts.addFile(10, "test-bundle", "/foo", "content")
+	ts.addFile(10, "test-bundle", "/foo", contents+"A")
 	ts.createManifests(10)
 
 	expSubs := []string{
@@ -41,7 +47,7 @@ func TestManifestFormats25to26(t *testing.T) {
 	// minversion now set to 20, but the MoM should still NOT have minversion
 	// in header due to format25 being used
 	ts.MinVersion = 20
-	ts.addFile(20, "test-bundle", "/foo", "new content")
+	ts.addFile(20, "test-bundle", "/foo", contents+"B")
 	ts.createManifests(20)
 
 	expSubs = []string{
@@ -59,10 +65,16 @@ func TestManifestFormats25to26(t *testing.T) {
 	ts.checkNotExists("www/20/Manifest.test-bundle.I.10")
 	ts.checkNotExists("www/20/os-core.I.10")
 
+	// Delta manifests should not exist in format 25
+	ts.mustHashFile("image/10/full/foo")
+	ts.mustHashFile("image/20/full/foo")
+	ts.createPack("test-bundle", 10, 20, ts.path("image"))
+	ts.checkNotExists("www/20/Manifest.test-bundle.D.10")
+
 	// updated to format26, minversion still set to 20, so we should see
 	// minversion  header in the MoM
 	ts.Format = 26
-	ts.addFile(30, "test-bundle", "/foo", "even newer content")
+	ts.addFile(30, "test-bundle", "/foo", contents+"C")
 	ts.createManifests(30)
 	expSubs = []string{
 		"MANIFEST\t26",
@@ -74,13 +86,19 @@ func TestManifestFormats25to26(t *testing.T) {
 	checkManifestContains(t, ts.Dir, "30", "test-bundle", expSubs...)
 	checkManifestContains(t, ts.Dir, "30", "MoM", "minversion:\t20")
 
-	ts.addFile(40, "test-bundle", "/foo", "more new content")
+	ts.addFile(40, "test-bundle", "/foo", contents+"D")
 	ts.createManifests(40)
 
 	// Updates in format 26 should support iterative manifests
 	checkManifestContains(t, ts.Dir, "40", "MoM", "\ttest-bundle.I.30", "\tos-core.I.30")
 	ts.checkExists("www/40/Manifest.test-bundle.I.30")
 	ts.checkExists("www/40/Manifest.os-core.I.30")
+
+	// Delta manifests should be created in format 26
+	ts.mustHashFile("image/30/full/foo")
+	ts.mustHashFile("image/40/full/foo")
+	ts.createPack("test-bundle", 30, 40, ts.path("image"))
+	checkDeltaManifest(ts, 30, 40, "test-bundle", 1)
 }
 
 func TestFormat25BadContentSize(t *testing.T) {

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -271,7 +271,7 @@ func WritePack(w io.Writer, fromManifest, toManifest *Manifest, outputDir, chroo
 		hasDelta[d.to.Hash] = d
 	}
 
-	if err = writeDeltaManifest(tw, outputDir, dManifest, toVersion); err != nil {
+	if err = writeDeltaManifestForFormat(tw, outputDir, dManifest, toVersion); err != nil {
 		return nil, err
 	}
 

--- a/swupd/packs_test.go
+++ b/swupd/packs_test.go
@@ -289,7 +289,7 @@ func checkDeltaManifest(ts *testSwupd, from, to int, bundle string, fileCount in
 	ts.checkExists(manifest)
 
 	expSubs := []string{
-		"MANIFEST\t1",
+		fmt.Sprintf("MANIFEST\t%d", ts.Format),
 		fmt.Sprintf("version:\t%d", from),
 		fmt.Sprintf("filecount:\t%d", fileCount),
 	}
@@ -325,6 +325,9 @@ func TestCreatePackNonConsecutiveDeltas(t *testing.T) {
 	defer ts.cleanup()
 
 	ts.Bundles = []string{"os-core", "contents"}
+
+	// Delta manifests are not supported in formats < 26
+	ts.Format = 26
 
 	contents := strings.Repeat("large", 1000)
 	if len(contents) < minimumSizeToMakeDeltaInBytes {
@@ -666,6 +669,10 @@ func TestTwoDeltasForTheSameTarget(t *testing.T) {
 
 	// Version 10.
 	ts.Bundles = []string{"os-core"}
+
+	// Delta manifests are not supported in formats < 26
+	ts.Format = 26
+
 	ts.addFile(10, "os-core", "/fileA", content+"A")
 	ts.addFile(10, "os-core", "/fileB", content+"B")
 	ts.createManifests(10)
@@ -700,6 +707,9 @@ func TestPackRenames(t *testing.T) {
 	defer ts.cleanup()
 
 	ts.Bundles = []string{"os-core"}
+
+	// Delta manifests are not supported in formats < 26
+	ts.Format = 26
 
 	content := strings.Repeat("CONTENT", 1000)
 
@@ -781,6 +791,9 @@ func TestPackNoDeltas(t *testing.T) {
 	defer ts.cleanup()
 
 	ts.Bundles = []string{"os-core", "bundle"}
+
+	// Delta manifests are not supported in formats < 26
+	ts.Format = 26
 
 	content := strings.Repeat("CONTENT", 1000)
 

--- a/swupd/swupd_test.go
+++ b/swupd/swupd_test.go
@@ -124,6 +124,10 @@ func TestFullRunDelta(t *testing.T) {
 
 	// Version 10.
 	ts.Bundles = []string{"os-core", "test-bundle"}
+
+	// Delta manifests are not supported in formats < 26
+	ts.Format = 26
+
 	ts.write("image/10/test-bundle/largefile", content)
 	ts.write("image/10/test-bundle/foo", "foo")
 	ts.write("image/10/test-bundle/foobarbaz", "foobarbaz")


### PR DESCRIPTION
This change creates format guards to prevent iterative and delta manifest generation in formats less than 26.